### PR TITLE
익명 게시판에서 중복 글/댓글을 판명하지 못하는 문제 개선

### DIFF
--- a/noduplicate.class.php
+++ b/noduplicate.class.php
@@ -93,7 +93,10 @@ class NoDuplicateAddon
 		{
 			if ($logged_info->member_srl)
 			{
-				$args->member_srl = $logged_info->member_srl;
+				$args->member_srl = array(
+					intval($logged_info->member_srl),
+					intval($logged_info->member_srl) * -1
+				);
 			}
 			else
 			{
@@ -163,7 +166,10 @@ class NoDuplicateAddon
 		{
 			if ($logged_info->member_srl)
 			{
-				$args->member_srl = $logged_info->member_srl;
+				$args->member_srl = array(
+					intval($logged_info->member_srl),
+					intval($logged_info->member_srl) * -1
+				);
 			}
 			else
 			{

--- a/queries/getComments.xml
+++ b/queries/getComments.xml
@@ -14,7 +14,7 @@
         <condition operation="equal" column="module_srl" var="module_srl" filter="number" />
 		<condition operation="equal" column="document_srl" var="document_srl" filter="number" pipe="and" />
 		<condition operation="notequal" column="comment_srl" var="not_comment_srl" filter="number" pipe="and" />
-        <condition operation="equal" column="member_srl" var="member_srl" filter="number" pipe="and" />
+        <condition operation="in" column="member_srl" var="member_srl" filter="number" pipe="and" />
 		<condition operation="equal" column="ipaddress" var="ipaddress" pipe="and" />
 		<condition operation="more" column="regdate" var="since_regdate" pipe="and" />
     </conditions>

--- a/queries/getDocuments.xml
+++ b/queries/getDocuments.xml
@@ -15,7 +15,7 @@
         <condition operation="equal" column="module_srl" var="module_srl" filter="number" />
         <condition operation="equal" column="category_srl" var="category_srl" filter="number" pipe="and" />
 		<condition operation="notequal" column="document_srl" var="not_document_srl" filter="number" pipe="and" />
-        <condition operation="equal" column="member_srl" var="member_srl" filter="number" pipe="and" />
+        <condition operation="in" column="member_srl" var="member_srl" filter="number" pipe="and" />
 		<condition operation="equal" column="ipaddress" var="ipaddress" pipe="and" />
 		<condition operation="more" column="regdate" var="since_regdate" pipe="and" />
     </conditions>


### PR DESCRIPTION
익명 게시판에서는 `member_srl`이 음수로 저장되기 때문에 중복 글/댓글을 판별하지 못합니다.

중복 여부를 검사하는 쿼리를 날릴 때 `member_srl`이 양수인 경우와 음수인 경우를 모두 조회하도록 수정하여 익명 게시판에서도 중복 글/댓글 등록을 방지할 수 있도록 개선하였습니다.